### PR TITLE
Stop Django from escaping HTML special chars in subject & plaintext body

### DIFF
--- a/email_from_template/templates/email_from_template/body.email
+++ b/email_from_template/templates/email_from_template/body.email
@@ -1,1 +1,1 @@
-{% block body %}{% endblock %}
+{% autoescape off %}{% block body %}{% endblock %}{% end autoescape %}

--- a/email_from_template/templates/email_from_template/subject.email
+++ b/email_from_template/templates/email_from_template/subject.email
@@ -1,1 +1,1 @@
-{% block subject %}{% endblock %}
+{% autoescape off %}{% block subject %}{% endblock %}{% endautoescape %}


### PR DESCRIPTION
Django escapes everything as HTML by default, but email subject lines & plaintext bodies aren't HTML. This causes email cilents to display things like `&#39;` instead of apostrophes.

# Test case

I tested with this template:

```
{% extends email_from_template %}

{% block subject %}
    It's you, {{ name }}
{% endblock %}

{% block body %}
    It's you, {{ name }}
{% endblock %}

{% block html %}
    It&#39;s you, {{ name }}
{% endblock %}
```

and this test code:

```python
from email_from_template import send_mail

mail = send_mail(
    template='email.email',
    context={
        'name': "Seamus O'Finnigan",
    },
    send_mail=False,
    recipient_list=['recipient@example.com'],
)

print(mail.subject)
# Before: It's you, Seamus O&#39;Finnigan
# After: It's you, Seamus O'Finnigan

print(mail.message())
# Before:
#     Content-Type: multipart/alternative;
#     boundary="===============5765706458858318303=="
#     MIME-Version: 1.0
#     Subject: It's you, Seamus O&#39;Finnigan
#     From: "Company Name" <support-email@test.domain>
#     To: recipient@example.com
#     Date: Tue, 01 Jun 2021 08:00:08 -0000
#     Message-ID: <162253440889.73639.11354725921584861680@Robins-MacBook-Pro.local>
#     
#     --===============5765706458858318303==
#     Content-Type: text/plain; charset="utf-8"
#     MIME-Version: 1.0
#     Content-Transfer-Encoding: 7bit
#     
#     It's you, Seamus O&#39;Finnigan
#     --===============5765706458858318303==
#     Content-Type: text/html; charset="utf-8"
#     MIME-Version: 1.0
#     Content-Transfer-Encoding: 7bit
#     
#     It&#39;s you, Seamus O&#39;Finnigan
#     --===============5765706458858318303==--

# After:
#     Content-Type: multipart/alternative;
#     boundary="===============1678701443333307192=="
#     MIME-Version: 1.0
#     Subject: It's you, Seamus O'Finnigan
#     From: "Company Name" <support-email@test.domain>
#     To: recipient@example.com
#     Date: Tue, 01 Jun 2021 07:58:11 -0000
#     Message-ID: <162253429159.73624.11121830294419373272@Robins-MacBook-Pro.local>

#     --===============1678701443333307192==
#     Content-Type: text/plain; charset="utf-8"
#     MIME-Version: 1.0
#     Content-Transfer-Encoding: 7bit

#     It's you, Seamus O'Finnigan
#     --===============1678701443333307192==
#     Content-Type: text/html; charset="utf-8"
#     MIME-Version: 1.0
#     Content-Transfer-Encoding: 7bit

#     It&#39;s you, Seamus O&#39;Finnigan
#     --===============1678701443333307192==--




```